### PR TITLE
HashContext

### DIFF
--- a/RDFSharp/Model/Serializers/RDFNTriples.cs
+++ b/RDFSharp/Model/Serializers/RDFNTriples.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -200,6 +201,7 @@ namespace RDFSharp.Model
                     RDFResource P = null;
                     RDFResource O = null;
                     RDFLiteral L = null;
+                    Dictionary<string, long> hashContext = new Dictionary<string, long>();
                     char[] openingBrackets = new char[] { '<' };
                     char[] closingBrackets = new char[] { '>' };
                     char[] trimmableChars  = new char[] { ' ', '\t', '\r', '\n' };
@@ -229,13 +231,15 @@ namespace RDFSharp.Model
                         string subj = tokens[0].TrimStart(openingBrackets)
                                                .TrimEnd(closingBrackets)
                                                .Replace("_:", "bnode:");
-                        S = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(subj));
+                        string finalSubj = RDFModelUtilities.ASCII_To_Unicode(subj);
+                        S = new RDFResource(finalSubj, hashContext);
                         #endregion
 
                         #region pred
                         string pred = tokens[1].TrimStart(openingBrackets)
                                                .TrimEnd(closingBrackets);
-                        P = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(pred));
+                        string finalPred = RDFModelUtilities.ASCII_To_Unicode(pred);
+                        P = new RDFResource(finalPred, hashContext);
                         #endregion
 
                         #region object
@@ -247,7 +251,8 @@ namespace RDFSharp.Model
                                                   .TrimEnd(closingBrackets)
                                                   .Replace("_:", "bnode:")
                                                   .Trim(trimmableChars);
-                            O = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(obj));
+                            string finalObj = RDFModelUtilities.ASCII_To_Unicode(obj);
+                            O = new RDFResource(finalObj, hashContext);
                         }
                         #endregion
 

--- a/RDFSharp/Model/Serializers/RDFTurtle.cs
+++ b/RDFSharp/Model/Serializers/RDFTurtle.cs
@@ -131,6 +131,7 @@ namespace RDFSharp.Model
         /// </summary>
         internal class RDFTurtleContext
         {
+            #region Properties
             /// <summary>
             /// Indicates the current subject
             /// </summary>
@@ -147,6 +148,16 @@ namespace RDFSharp.Model
             /// Indicates the current position in the input string
             /// </summary>
             internal int Position { get; set; }
+            /// <summary>
+            /// Context for Uri hashing
+            /// </summary>
+            internal Dictionary<string, long> HashContext { get; set; }
+            #endregion
+
+            #region Ctors
+            internal RDFTurtleContext()
+                => HashContext = new Dictionary<string, long>();
+            #endregion
         }
         #endregion
 
@@ -383,7 +394,7 @@ namespace RDFSharp.Model
             {
                 object value = ParseValue(turtleData, turtleContext, result);
                 if (value is Uri)
-                    turtleContext.Subject = new RDFResource(value.ToString());
+                    turtleContext.Subject = new RDFResource(value.ToString(), turtleContext.HashContext);
                 else if (value is RDFResource valueResource)
                     turtleContext.Subject = valueResource;
                 else if (value != null)
@@ -416,7 +427,7 @@ namespace RDFSharp.Model
             // Predicate is a normal resource
             object predicate = ParseValue(turtleData, turtleContext, result);
             if (predicate is Uri)
-                return new RDFResource(predicate.ToString());
+                return new RDFResource(predicate.ToString(), turtleContext.HashContext);
             else if (predicate is RDFResource)
                 return (RDFResource)predicate;
             else
@@ -489,7 +500,7 @@ namespace RDFSharp.Model
                 default:
                     object value = ParseValue(turtleData, turtleContext, result); //Uri or RDFPatternMember
                     if (value is Uri)
-                        turtleContext.Object = new RDFResource(value.ToString());
+                        turtleContext.Object = new RDFResource(value.ToString(), turtleContext.HashContext);
                     else if (value is RDFPatternMember pmemberValue)
                         turtleContext.Object = pmemberValue;
                     break;

--- a/RDFSharp/Query/Mirella/Algebra/Abstractions/RDFPatternMember.cs
+++ b/RDFSharp/Query/Mirella/Algebra/Abstractions/RDFPatternMember.cs
@@ -16,6 +16,7 @@
 
 using RDFSharp.Model;
 using System;
+using System.Collections.Generic;
 
 namespace RDFSharp.Query
 {

--- a/RDFSharp/Store/Serializers/RDFNQuads.cs
+++ b/RDFSharp/Store/Serializers/RDFNQuads.cs
@@ -16,6 +16,7 @@
 
 using RDFSharp.Model;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -204,6 +205,7 @@ namespace RDFSharp.Store
                     RDFResource O = null;
                     RDFLiteral L = null;
                     RDFContext C = new RDFContext();
+                    Dictionary<string, long> hashContext = new Dictionary<string, long>();
                     while ((nquad = sr.ReadLine()) != null)
                     {
                         nquadIndex++;
@@ -235,13 +237,13 @@ namespace RDFSharp.Store
                         string subj = tokens[0].TrimStart(new char[] { '<' })
                                                .TrimEnd(new char[] { '>' })
                                                .Replace("_:", "bnode:");
-                        S = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(subj));
+                        S = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(subj), hashContext);
                         #endregion
 
                         #region pred
                         string pred = tokens[1].TrimStart(new char[] { '<' })
                                                .TrimEnd(new char[] { '>' });
-                        P = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(pred));
+                        P = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(pred), hashContext);
                         #endregion
 
                         #region object
@@ -253,7 +255,7 @@ namespace RDFSharp.Store
                                                   .TrimEnd(new char[] { '>' })
                                                   .Replace("_:", "bnode:")
                                                   .Trim(new char[] { ' ', '\n', '\t', '\r' });
-                            O = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(obj));
+                            O = new RDFResource(RDFModelUtilities.ASCII_To_Unicode(obj), hashContext);
                         }
                         #endregion
 

--- a/RDFSharp/Store/Serializers/RDFTriG.cs
+++ b/RDFSharp/Store/Serializers/RDFTriG.cs
@@ -269,7 +269,7 @@ namespace RDFSharp.Store
 
 		        if (value is Uri || (value is RDFResource resValue && !resValue.IsBlank)) //We don't accept blank contexts
                 {
-			        contextOrSubject = new RDFResource(value.ToString());
+			        contextOrSubject = new RDFResource(value.ToString(), trigContext.HashContext);
 			        foundContextOrSubject = true;
 		        }
                 else

--- a/RDFSharp/Store/Serializers/RDFTriX.cs
+++ b/RDFSharp/Store/Serializers/RDFTriX.cs
@@ -118,6 +118,7 @@ namespace RDFSharp.Store
 
                             #endregion Guards
 
+                            Dictionary<string, long> hashContext = new Dictionary<string, long>();
                             IEnumerator graphEnum = trixDoc.DocumentElement.ChildNodes.GetEnumerator();
                             while (graphEnum != null && graphEnum.MoveNext())
                             {
@@ -161,7 +162,7 @@ namespace RDFSharp.Store
 
                                     //<triple> gives a triple of the graph
                                     else if (graphChild.Name.Equals("triple", StringComparison.Ordinal) && graphChild.ChildNodes.Count == 3)
-                                        RDFSharp.Model.RDFTriX.ParseTriXTriple(graphs[graphID], graphChild);
+                                        RDFSharp.Model.RDFTriX.ParseTriXTriple(graphs[graphID], graphChild, hashContext);
                                     
                                     //Neither <uri> or a well-formed <triple>: exception must be raised
                                     else


### PR DESCRIPTION
Improves the performances of RDF parsers by making use of an internal hash context which saves redundant calls to RDFModelUtilities.CreateHash